### PR TITLE
Fix Symfony 2.2.* compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.1.*,<2.3.*-dev",
+        "symfony/framework-bundle": ">=2.1,<2.3-dev",
         "symfony/options-resolver": ">=2.1.3"
     },
     "autoload": {


### PR DESCRIPTION
Will install Symfony between 2.1.\* and 2.2.\* versions.

Works fine for me.

Reference to issue #10.
