### PR TITLE
Fix unhidden field by changing wrong block_prefix param

### DIFF
--- a/Resources/views/Macro/paybox.html.twig
+++ b/Resources/views/Macro/paybox.html.twig
@@ -1,5 +1,5 @@
 {%- macro input(field) -%}
-    <input type="{{ field.vars.block_prefixes[2] }}" name="{{ field.vars.name }}" {% if field.vars.value is not empty %}value="{{ field.vars.value }}" {% endif %}/>
+    <input type="{{ field.vars.block_prefixes[1] }}" name="{{ field.vars.name }}" {% if field.vars.value is not empty %}value="{{ field.vars.value }}" {% endif %}/>
 {%- endmacro -%}
 
 {%- macro form(form) -%}


### PR DESCRIPTION
Field was unhidden because of vrong block_prefix parameter, this PR will fix that.

Tested only on SF2.3, maybe the symfony version is the origin of this issue ?

Fix ticket #14.
