### PR TITLE
Fix Call to undefined method Symfony\Component\Config\Definition\Builder...

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -83,7 +83,7 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('algorithm')->defaultValue('sha512')->end()
                                 ->scalarNode('key')->isRequired()->end()
-                                ->scalarNode('signature_name')->default('Sign')->end()
+                                ->scalarNode('signature_name')->defaultValue('Sign')->end()
                             ->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
...\ScalarNodeDefinition::default()
