### PR TITLE
fix base name of request form

### DIFF
--- a/Paybox/System/Base/Request.php
+++ b/Paybox/System/Base/Request.php
@@ -121,7 +121,7 @@ class Request extends Paybox
         $options['csrf_protection'] = false;
 
         $parameters = $this->getParameters();
-        $builder = $this->factory->createBuilder('form', $parameters, $options);
+        $builder = $this->factory->createNamedBuilder('', 'form', $parameters, $options);
 
         foreach ($parameters as $key => $value) {
             $builder->add($key, 'hidden');


### PR DESCRIPTION
The actual form generate inputs with the name formatted as `form[PBX_****]`. This fix change the base name and generate names like `PBX_****`. 
