### PR TITLE
Add public_key in parameters if not defined

### DIFF
--- a/DependencyInjection/LexikPayboxExtension.php
+++ b/DependencyInjection/LexikPayboxExtension.php
@@ -31,6 +31,7 @@ class LexikPayboxExtension extends Extension
 
         if (null === $config['parameters']['public_key']) {
             $config['parameters']['public_key'] = __DIR__ . '/../Resources/config/paybox_public_key.pem';
+            $container->setParameter('lexik_paybox.parameters', $config['parameters']);
         }
 
         $container->setParameter('lexik_paybox.public_key', $config['parameters']['public_key']);


### PR DESCRIPTION
If the parameter  `public_key` is not defined in config.yml the default value is not accessible in `lexik_paybox.parameters`. As `Lexik\Bundle\PayboxBundle\Paybox\System\Base\Response` use the value from `lexik_paybox.parameters` the validation can not work.