### PR TITLE
conform urlencode to the RFC 3986

### DIFF
--- a/Paybox/System/Base/Response.php
+++ b/Paybox/System/Base/Response.php
@@ -137,13 +137,16 @@ class Response
 
         $publicKey = openssl_get_publickey($cert);
 
+        // conform datas to the RFC 3986
+        $datas = str_replace('+', '%20', Paybox::stringify($this->data));
+
         $result = openssl_verify(
-            Paybox::stringify($this->data),
+            $datas,
             $this->signature,
             $publicKey
         );
 
-        $this->logger->info(Paybox::stringify($this->data));
+        $this->logger->info($datas);
         $this->logger->info(base64_encode($this->signature));
 
         if ($result == 1) {


### PR DESCRIPTION
php urlencode() function differs from the RFC 3986 and replace spaces by "+" instead of "%20" witch cause invalid signature check when the PBX_CMD contain some spaces.
