### PR TITLE
Missing parameters in doc exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ To create your own listener, you just have to make it wait for the "paybox.ipn_r
 For example the listener of the bundle:
 
 ```yml
+parameters:
+    lexik_paybox.sample_response_listener.class: 'Lexik\Bundle\PayboxBundle\Listener\SampleIpnListener'
+
 services:
     ...
     lexik_paybox.sample_response_listener:


### PR DESCRIPTION
I guess we need that for simple installation