### PR TITLE
Fix deprecated route options

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,4 @@
 lexik_paybox_ipn:
     pattern:  /payment-ipn/{time}
     defaults: { _controller: LexikPayboxBundle:Default:ipn }
-    requirements:
-        _method: GET|POST
+    methods: [GET, POST]


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.