### PR TITLE
Composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,8 @@ Installation
 
 Installation with composer :
 
-```json
-    ...
-    "require": {
-        ...
-        "lexik/paybox-bundle": "dev-master",
-        ...
-    },
-    ...
+```bash
+composer require lexik/paybox-bundle
 ```
 
 Add this bundle to your app/AppKernel.php :


### PR DESCRIPTION
This is a more generic solution to add your bundle.

Composer will automatically find and select the right version.