### PR TITLE
Remove PHPUnit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "kriswallsmith/buzz": "~0.15"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-4": { "Lexik\\Bundle\\PayboxBundle\\": "" }


### PR DESCRIPTION
PHPUnit should not be added as a dependency.

This is a huge dep and users in most case already have PHPUnit on the system.