### PR TITLE
DEPRECATED Pattern vs Path

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 lexik_paybox_ipn:
-    pattern:  /payment-ipn/{time}
+    path:  /payment-ipn/{time}
     defaults: { _controller: LexikPayboxBundle:Default:ipn }
     methods: [GET, POST]


### PR DESCRIPTION
The "pattern" option in file "~/vendor/lexik/paybox-bundle/Resources/config/routing.yml" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.

Hi, 

i have no advanced knowledge of pattern vs path but still this notice appears in symfony 2.7.5

Thanks guys,