### PR TITLE
Replace request dependency by request_stack in response_handler

### DIFF
--- a/Paybox/System/Base/Response.php
+++ b/Paybox/System/Base/Response.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class Response
@@ -53,14 +54,14 @@ class Response
     /**
      * Contructor.
      *
-     * @param HttpRequest              $request
+     * @param RequestStack             $requestStack
      * @param LoggerInterface          $logger
      * @param EventDispatcherInterface $dispatcher
      * @param array                    $parameters
      */
-    public function __construct(HttpRequest $request, LoggerInterface $logger, EventDispatcherInterface $dispatcher, array $parameters)
+    public function __construct(RequestStack $requestStack, LoggerInterface $logger, EventDispatcherInterface $dispatcher, array $parameters)
     {
-        $this->request    = $request;
+        $this->request    = $requestStack->getCurrentRequest();
         $this->logger     = $logger;
         $this->dispatcher = $dispatcher;
         $this->parameters = $parameters;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,7 +15,7 @@ services:
 
     lexik_paybox.response_handler:
         class:     '%lexik_paybox.response_handler.class%'
-        arguments: ['@request=', '@logger', '@event_dispatcher', '%lexik_paybox.parameters%']
+        arguments: ['@request_stack', '@logger', '@event_dispatcher', '%lexik_paybox.parameters%']
         tags:
             - { name: monolog.logger, channel: payment }
 

--- a/Tests/Paybox/System/Base/ResponseTest.php
+++ b/Tests/Paybox/System/Base/ResponseTest.php
@@ -36,6 +36,12 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $request->request = new ParameterBag($parameters);
 
+        $requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
         /** @var LoggerInterface $logger */
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         foreach ($messages as $i => $message) {
@@ -59,7 +65,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->_response = new Response($request, $logger, $dispatcher, $parameters);
+        $this->_response = new Response($requestStack, $logger, $dispatcher, $parameters);
     }
 
     protected function tearDown()


### PR DESCRIPTION
This is for fixing the use of request in response handler.

Trying to get the request directly as a dependency is not a good practice. And is not currently working in symfony 3.0.

I adapt the tests in the file as well.