### PR TITLE
Fix allowed value for pbx card type

### DIFF
--- a/Paybox/System/Base/ParameterResolver.php
+++ b/Paybox/System/Base/ParameterResolver.php
@@ -139,7 +139,9 @@ class ParameterResolver extends AbstractParameterResolver
                 'CB',
                 'VISA',
                 'EUROCARD_MASTERCARD',
-                'AMEX'
+                'AMEX',
+                'AURORE',
+                'E_CARD',
             ))
         ;
     }


### PR DESCRIPTION
Add AURORE and E_CARD as allowed value for PBX_TYPECARTE. It's the same behavior as CB or VISA.