### PR TITLE
Fix Symfony version detection for forms

### DIFF
--- a/Paybox/System/Base/Request.php
+++ b/Paybox/System/Base/Request.php
@@ -148,9 +148,9 @@ class Request extends AbstractRequest
         $options['csrf_protection'] = false;
 
         $parameters = $this->getParameters();
-        // If symfony version is 3.* then we use the FQCN for form types
+        // If symfony version is >=2.8 then we use the FQCN for form types
         // Else we use the IDs.
-        if (version_compare(Kernel::VERSION, '3.0.0') >= 0) {
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $builder = $this->factory->createNamedBuilder(
                 '',
                 'Symfony\Component\Form\Extension\Core\Type\FormType',


### PR DESCRIPTION
This is a proper and safer version of #67.

Remember one gold rule: Never use kernel version comparison if you're not working with the kernel itself.

See discussion: https://github.com/lexik/LexikPayboxBundle/pull/67/files#r59726611