### PR TITLE
Fix support for Twig 2.*

### DIFF
--- a/Resources/views/Macro/paybox.html.twig
+++ b/Resources/views/Macro/paybox.html.twig
@@ -3,7 +3,8 @@
 {%- endmacro -%}
 
 {%- macro form(form) -%}
+    {% import _self as self %}
     {%- for field in form -%}
-        {{ _self.input(field) }}
+        {{ self.input(field) }}
     {%- endfor -%}
 {%- endmacro -%}


### PR DESCRIPTION
In Twig 2.* I've an error : 
```Impossible to invoke a method ("input") on a string variable ("LexikPayboxBundle:Macro:paybox.html.twig").```

Apparantly in v2, twig calls to _self directly give a string ""LexikPayboxBundle:Macro:paybox.html.twig" instead a twig template object.

@lexikteam 